### PR TITLE
meson: declare minimum version of 1.1.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project(
     'pms-utils',
     'cpp',
     version: files('version'),
+    meson_version: '>=1.1.0',
     default_options: ['warning_level=3', 'cpp_std=c++20'],
 )
 

--- a/subprojects/bindings-python/meson.build
+++ b/subprojects/bindings-python/meson.build
@@ -2,6 +2,7 @@ project(
     'bindings-python',
     'cpp',
     version: files('version'),
+    meson_version: '>=1.1.0',
     default_options: ['warning_level=3', 'cpp_std=c++20'],
 )
 


### PR DESCRIPTION
meson.options was introduced in meson version 1.1.0.

Alternatively, `meson.options` could be renamed to `meson_options.txt`